### PR TITLE
[UI] Implement menu dropdown interface with project list

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,29 @@
+version: '3'
+
+tasks:
+  dev:
+    desc: Start local development server
+    cmds:
+      - npm run start
+
+  lint:
+    desc: Run ESLint on TypeScript files
+    cmds:
+      - npm run lint
+
+  test:
+    desc: Run Jest tests
+    cmds:
+      - npm run test
+
+  typecheck:
+    desc: Run TypeScript type checking
+    cmds:
+      - npm run typecheck
+
+  check:
+    desc: Run all pre-commit checks (lint, typecheck, test)
+    cmds:
+      - task: lint
+      - task: typecheck
+      - task: test

--- a/src/index.html
+++ b/src/index.html
@@ -2,11 +2,10 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Hello World!</title>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Killall-Tofu</title>
   </head>
   <body>
-    <h1>💖 Hello World!</h1>
-    <p>Welcome to your Electron application.</p>
+    <div id="root"></div>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,9 +100,17 @@ const createWindow = (): void => {
   // Load the index.html of the app
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
 
-  // Show window when ready
+  // Position window near tray icon
   mainWindow.once('ready-to-show', () => {
-    if (mainWindow) {
+    if (mainWindow && tray) {
+      const trayBounds = tray.getBounds();
+      const windowBounds = mainWindow.getBounds();
+      
+      // Position window below the tray icon (macOS menu bar)
+      const x = Math.round(trayBounds.x + (trayBounds.width / 2) - (windowBounds.width / 2));
+      const y = Math.round(trayBounds.y + trayBounds.height + 4);
+      
+      mainWindow.setPosition(x, y, false);
       mainWindow.show();
     }
   });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -26,7 +26,4 @@
  * ```
  */
 
-import './index.css';
-
-// Initial renderer setup - replace with React app initialization
-// console.log('👋 This message is being logged by "renderer.js", included via webpack');
+import './renderer/index';

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -1,0 +1,53 @@
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: linear-gradient(to bottom, #1a1a1a, #0d0d0d);
+  color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', sans-serif;
+  font-size: 13px;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.app-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.app-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.settings-button,
+.quit-button {
+  padding: 4px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.settings-button:hover,
+.quit-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.quit-button {
+  background: rgba(255, 50, 50, 0.2);
+  border-color: rgba(255, 50, 50, 0.3);
+}
+
+.quit-button:hover {
+  background: rgba(255, 50, 50, 0.3);
+  border-color: rgba(255, 50, 50, 0.4);
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+
+import { Project, ProjectStatus } from '../shared/types';
+
 import ProjectList from './components/ProjectList';
 import Header from './components/Header';
-import { Project, ProjectStatus } from '../shared/types';
 import './App.css';
 
 const mockProjects: Project[] = [

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import ProjectList from './components/ProjectList';
+import Header from './components/Header';
+import { Project, ProjectStatus } from '../shared/types';
+import './App.css';
+
+const mockProjects: Project[] = [
+  {
+    id: '1',
+    path: '/Users/developer/projects/aws-infrastructure',
+    status: 'scheduled' as ProjectStatus,
+    discoveredAt: new Date(Date.now() - 3600000),
+    destroyAt: new Date(Date.now() + 7200000),
+    config: {
+      version: 1,
+      timeout: '2 hours',
+      name: 'AWS Development Stack',
+      tags: ['aws', 'development'],
+      command: 'terraform destroy -auto-approve'
+    }
+  },
+  {
+    id: '2', 
+    path: '/Users/developer/projects/test-environment',
+    status: 'scheduled' as ProjectStatus,
+    discoveredAt: new Date(Date.now() - 1800000),
+    destroyAt: new Date(Date.now() + 900000),
+    config: {
+      version: 1,
+      timeout: '30 minutes',
+      name: 'Testing Environment',
+      tags: ['testing', 'temporary'],
+      command: 'docker-compose down -v'
+    }
+  },
+  {
+    id: '3',
+    path: '/Users/developer/projects/staging-cluster',
+    status: 'destroying' as ProjectStatus,
+    discoveredAt: new Date(Date.now() - 7200000),
+    destroyAt: new Date(Date.now() - 60000),
+    config: {
+      version: 1,
+      timeout: '4 hours',
+      name: 'Staging Kubernetes Cluster',
+      tags: ['kubernetes', 'staging'],
+      command: 'kubectl delete namespace staging'
+    }
+  },
+  {
+    id: '4',
+    path: '/Users/developer/projects/dev-database',
+    status: 'destroyed' as ProjectStatus,
+    discoveredAt: new Date(Date.now() - 14400000),
+    destroyAt: new Date(Date.now() - 7200000),
+    config: {
+      version: 1,
+      timeout: '1 hour',
+      name: 'Dev Database Instance',
+      tags: ['database', 'development']
+    }
+  }
+];
+
+function App() {
+  const [projects] = useState<Project[]>(mockProjects);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredProjects = projects.filter(project => {
+    const searchLower = searchTerm.toLowerCase();
+    const name = project.config.name?.toLowerCase() || '';
+    const path = project.path.toLowerCase();
+    const tags = project.config.tags?.join(' ').toLowerCase() || '';
+    
+    return name.includes(searchLower) || 
+           path.includes(searchLower) ||
+           tags.includes(searchLower);
+  });
+
+  const activeProjects = filteredProjects.filter(p => 
+    ['scheduled', 'destroying'].includes(p.status)
+  );
+
+  const recentProjects = filteredProjects.filter(p => 
+    ['destroyed', 'failed', 'cancelled'].includes(p.status)
+  );
+
+  return (
+    <div className="app">
+      <Header 
+        searchTerm={searchTerm}
+        onSearchChange={setSearchTerm}
+        activeCount={activeProjects.length}
+      />
+      
+      <div className="app-content">
+        <ProjectList 
+          activeProjects={activeProjects}
+          recentProjects={recentProjects}
+        />
+      </div>
+
+      <div className="app-footer">
+        <button className="settings-button">
+          Settings
+        </button>
+        <button className="quit-button">
+          Quit
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/src/renderer/components/Header.css
+++ b/src/renderer/components/Header.css
@@ -1,0 +1,57 @@
+.header {
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.header-icon {
+  font-size: 16px;
+  margin-right: 6px;
+}
+
+.header-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.active-badge {
+  margin-left: auto;
+  background: #ff4444;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: bold;
+}
+
+.search-container {
+  position: relative;
+}
+
+.search-input {
+  width: 100%;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #ffffff;
+  font-size: 12px;
+  outline: none;
+  transition: all 0.2s;
+}
+
+.search-input::placeholder {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.search-input:focus {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+}

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import './Header.css';
+
+interface HeaderProps {
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
+  activeCount: number;
+}
+
+const Header: React.FC<HeaderProps> = ({ searchTerm, onSearchChange, activeCount }) => {
+  return (
+    <div className="header">
+      <div className="header-title">
+        <span className="header-icon">🔥</span>
+        <span className="header-text">Killall-Tofu</span>
+        {activeCount > 0 && (
+          <span className="active-badge">{activeCount}</span>
+        )}
+      </div>
+      
+      <div className="search-container">
+        <input
+          type="text"
+          className="search-input"
+          placeholder="Search projects..."
+          value={searchTerm}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Header;

--- a/src/renderer/components/ProjectItem.css
+++ b/src/renderer/components/ProjectItem.css
@@ -1,0 +1,152 @@
+.project-item {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 8px 10px;
+  transition: all 0.2s;
+  position: relative;
+}
+
+.project-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.project-item.status-normal {
+  border-left: 3px solid #4caf50;
+}
+
+.project-item.status-warning {
+  border-left: 3px solid #ff9800;
+  background: rgba(255, 152, 0, 0.05);
+}
+
+.project-item.status-critical {
+  border-left: 3px solid #f44336;
+  background: rgba(244, 67, 54, 0.05);
+  animation: pulse 2s infinite;
+}
+
+.project-item.status-destroying {
+  border-left: 3px solid #2196f3;
+  background: rgba(33, 150, 243, 0.05);
+}
+
+.project-item.status-completed {
+  border-left: 3px solid #666;
+  opacity: 0.7;
+}
+
+.project-item.status-failed {
+  border-left: 3px solid #f44336;
+  opacity: 0.7;
+}
+
+.project-item.status-cancelled {
+  border-left: 3px solid #999;
+  opacity: 0.6;
+}
+
+@keyframes pulse {
+  0%, 100% { background: rgba(244, 67, 54, 0.05); }
+  50% { background: rgba(244, 67, 54, 0.1); }
+}
+
+.project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.project-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #ffffff;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-time {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  margin-left: 8px;
+}
+
+.project-status {
+  font-size: 11px;
+  color: #2196f3;
+  font-weight: 500;
+  margin-left: 8px;
+}
+
+.project-path {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 4px;
+}
+
+.project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 4px 0;
+}
+
+.tag {
+  font-size: 10px;
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.project-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.action-button {
+  padding: 4px 8px;
+  font-size: 11px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.action-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.extend-button {
+  background: rgba(76, 175, 80, 0.2);
+  border-color: rgba(76, 175, 80, 0.3);
+}
+
+.extend-button:hover {
+  background: rgba(76, 175, 80, 0.3);
+  border-color: rgba(76, 175, 80, 0.4);
+}
+
+.cancel-button {
+  background: rgba(244, 67, 54, 0.2);
+  border-color: rgba(244, 67, 54, 0.3);
+}
+
+.cancel-button:hover {
+  background: rgba(244, 67, 54, 0.3);
+  border-color: rgba(244, 67, 54, 0.4);
+}

--- a/src/renderer/components/ProjectItem.tsx
+++ b/src/renderer/components/ProjectItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { Project } from '../../shared/types';
 import './ProjectItem.css';
 

--- a/src/renderer/components/ProjectItem.tsx
+++ b/src/renderer/components/ProjectItem.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Project } from '../../shared/types';
+import './ProjectItem.css';
+
+interface ProjectItemProps {
+  project: Project;
+}
+
+const getTimeRemaining = (destroyAt: Date): string => {
+  const now = new Date();
+  const diff = destroyAt.getTime() - now.getTime();
+  
+  if (diff <= 0) return 'Now';
+  
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+const getStatusColor = (project: Project): string => {
+  const now = new Date();
+  const timeRemaining = project.destroyAt.getTime() - now.getTime();
+  
+  if (project.status === 'destroying') return 'status-destroying';
+  if (project.status === 'destroyed') return 'status-completed';
+  if (project.status === 'failed') return 'status-failed';
+  if (project.status === 'cancelled') return 'status-cancelled';
+  
+  if (timeRemaining < 15 * 60 * 1000) return 'status-critical';
+  if (timeRemaining < 60 * 60 * 1000) return 'status-warning';
+  return 'status-normal';
+};
+
+const ProjectItem: React.FC<ProjectItemProps> = ({ project }) => {
+  const isActive = ['scheduled', 'destroying'].includes(project.status);
+  const statusColor = getStatusColor(project);
+  
+  return (
+    <div className={`project-item ${statusColor}`}>
+      <div className="project-header">
+        <div className="project-name">
+          {project.config.name || 'Unnamed Project'}
+        </div>
+        {isActive && project.status !== 'destroying' && (
+          <div className="project-time">
+            {getTimeRemaining(project.destroyAt)}
+          </div>
+        )}
+        {project.status === 'destroying' && (
+          <div className="project-status">Destroying...</div>
+        )}
+      </div>
+      
+      <div className="project-path">{project.path}</div>
+      
+      {project.config.tags && project.config.tags.length > 0 && (
+        <div className="project-tags">
+          {project.config.tags.map(tag => (
+            <span key={tag} className="tag">{tag}</span>
+          ))}
+        </div>
+      )}
+      
+      {isActive && (
+        <div className="project-actions">
+          <button className="action-button extend-button">
+            +30m
+          </button>
+          <button className="action-button cancel-button">
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectItem;

--- a/src/renderer/components/ProjectList.css
+++ b/src/renderer/components/ProjectList.css
@@ -1,0 +1,44 @@
+.project-list {
+  padding: 8px;
+}
+
+.project-section {
+  margin-bottom: 12px;
+}
+
+.section-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  margin: 8px 4px 6px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.project-items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  text-align: center;
+}
+
+.empty-message {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 8px;
+}
+
+.empty-hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.4);
+  max-width: 250px;
+  line-height: 1.4;
+}

--- a/src/renderer/components/ProjectList.tsx
+++ b/src/renderer/components/ProjectList.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import ProjectItem from './ProjectItem';
+
 import { Project } from '../../shared/types';
+
+import ProjectItem from './ProjectItem';
 import './ProjectList.css';
 
 interface ProjectListProps {

--- a/src/renderer/components/ProjectList.tsx
+++ b/src/renderer/components/ProjectList.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import ProjectItem from './ProjectItem';
+import { Project } from '../../shared/types';
+import './ProjectList.css';
+
+interface ProjectListProps {
+  activeProjects: Project[];
+  recentProjects: Project[];
+}
+
+const ProjectList: React.FC<ProjectListProps> = ({ activeProjects, recentProjects }) => {
+  return (
+    <div className="project-list">
+      {activeProjects.length > 0 && (
+        <div className="project-section">
+          <h3 className="section-title">Active Infrastructure</h3>
+          <div className="project-items">
+            {activeProjects.map(project => (
+              <ProjectItem key={project.id} project={project} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {recentProjects.length > 0 && (
+        <div className="project-section">
+          <h3 className="section-title">Recent Activity</h3>
+          <div className="project-items">
+            {recentProjects.map(project => (
+              <ProjectItem key={project.id} project={project} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {activeProjects.length === 0 && recentProjects.length === 0 && (
+        <div className="empty-state">
+          <p className="empty-message">No projects found</p>
+          <p className="empty-hint">Add .killall.yaml files to your projects to start tracking them</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectList;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1,0 +1,38 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background: transparent;
+  overflow: hidden;
+}
+
+#root {
+  height: 100vh;
+  overflow: hidden;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+
 import App from './App';
 import './index.css';
 


### PR DESCRIPTION
## What has changed
- Added React-based dropdown UI for menu bar application
- Created Taskfile.yaml for standardized build scripts
- Implemented project list with mocked data

## Description
This PR implements the core UI for the Killall-Tofu menu bar application. The interface displays a dropdown window (350x400px) that shows active infrastructure projects scheduled for destruction. 

Key features include:
- Dark-themed dropdown interface that matches macOS menu bar aesthetics
- Project list showing active and recent infrastructure with status indicators
- Time remaining display with color coding (green >1hr, yellow 15-60min, red <15min)
- Search functionality to filter projects by name, path, or tags
- Action buttons for extending timers (+30m) and cancelling destructions
- Responsive window positioning below the tray icon

The UI uses React components with proper separation of concerns and includes mocked project data for demonstration purposes.

## How to test
1. Clone the branch and install dependencies: `npm install`
2. Start the development server: `task dev` or `npm run start`
3. Look for the green circle icon in the menu bar
4. Click the tray icon to open the dropdown window
5. Verify the project list displays with proper styling and color indicators
6. Test the search functionality by typing in the search box
7. Verify action buttons are visible on active projects